### PR TITLE
Allow specifying the admin bind host

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ If the default value match with your choice you can omit it.
 
 ```
 Options and default values:
---server-port=8079              Application port where the collected metrics are available
+--server-port=8079              Application listen port where the collected metrics are available
+--server-host=""                Application listen host where the collected metrics are available (empty for all hosts)
 --log-level=info                Logging level (debug, info, warn, error)
 --vici-network=tcp              Vici network scheme (tcp, udp, unix)
 --vici-address=localhost:4502   IP address or hostname with a port or unix socket path
@@ -38,7 +39,7 @@ make build
 
 Run the binary with optional arguments provided:
 ```bash
-./ipsec-prometheus-exporter [--server-port=8079] [--log-level=info] [--vici-network=tcp] [--vici-address=localhost:4502]
+./ipsec-prometheus-exporter [--server-port=8079] [--server-host=""] [--log-level=info] [--vici-network=tcp] [--vici-address=localhost:4502]
 ```
 
 ## Docker image


### PR DESCRIPTION
Allow specifying the admin bind host, besides the already supported `-server-port`. As such, this change adds a new argument `-server-host` while keeping the existing behavior (listen on all interfaces).

Demo:
```
# Original

$ go run .
{"level":"info","ts":"2025-05-09T20:34:10.314+0100","caller":"ipsec-prometheus-exporter/main.go:91","msg":"Starting admin server on ':8079'."}

$ netstat  -an | grep LISTEN | grep 8079
tcp46      0      0  *.8079                 *.*                    LISTEN



# With -server-host

$ go run . -server-host localhost
{"level":"info","ts":"2025-05-09T20:32:39.055+0100","caller":"ipsec-prometheus-exporter/main.go:91","msg":"Starting admin server on 'localhost:8079'."}

$ netstat  -an | grep LISTEN | grep 8079
tcp4       0      0  127.0.0.1.8079         *.*                    LISTEN
```