### PR TITLE
Add CGO_ENABLED=0 for release-binary

### DIFF
--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -36,6 +36,8 @@ jobs:
           GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -v -o "dist/${{ env.BINARY_NAME }}"
         fi
         tar -czvf ${{ env.BINARY_NAME }}-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz -C dist/ .
+      env:
+        CGO_ENABLED: 0
 
     - name: Upload binary to release
       uses: softprops/action-gh-release@v2


### PR DESCRIPTION
Sets CGO_ENABLED=0 so that it can be run in any distribution without warnings about libc incompatibility