### PR TITLE
Add configured connections collector for down tunnel detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # IPSec Prometheus Exporter
 
-_The IPSec Prometheus exporter subscribes to the strongSwan via Vici API and exposes [Security Associations](https://github.com/strongswan/strongswan/blob/master/src/libcharon/plugins/vici/README.md#list-sa) (SAs) metrics. Optionally [X509 certificate](https://github.com/strongswan/strongswan/blob/master/src/libcharon/plugins/vici/README.md#list-certs) metrics can be turned on._
+_The IPSec Prometheus exporter subscribes to the strongSwan via Vici API and exposes [Security Associations](https://github.com/strongswan/strongswan/blob/master/src/libcharon/plugins/vici/README.md#list-sa) (SAs) and [configured connections](https://github.com/strongswan/strongswan/blob/master/src/libcharon/plugins/vici/README.md#list-conns) metrics. Optionally [X509 certificate](https://github.com/strongswan/strongswan/blob/master/src/libcharon/plugins/vici/README.md#list-certs) metrics can be turned on._
 
 Collected metrics (together with application metrics) are exposed on `/metrics` endpoint. Prometheus target is then configured with this endpoint and port e.g. `http://localhost:8079/metrics`.
 
@@ -23,7 +23,24 @@ Options and default values:
 --enable-cert-metrics=false     Enable collecting of X509 certificate metrics (true, false)
 ```
 
-## Value Definition
+## Metrics
+
+### Configured Connections
+
+These metrics are always present for every configured connection in strongSwan, regardless of whether the tunnel is currently active. This enables detection of down tunnels by comparing configured vs active SAs.
+
+| Metric | Labels | Description |
+|--------|--------|-------------|
+| `strongswan_conn_configured` | `conn_name` | Always 1 for each configured IKE connection |
+| `strongswan_conn_child_configured` | `conn_name`, `child_name`, `local_ts`, `remote_ts` | Always 1 for each configured child SA |
+
+**Detecting down tunnels:** A tunnel is down when `strongswan_conn_child_configured` exists for a `child_name` but there is no corresponding `strongswan_sa_status` metric. Example PromQL:
+
+```promql
+strongswan_conn_child_configured unless on (child_name) strongswan_sa_status
+```
+
+### SA Status Values
 
 | Metric              | Value | Description                                        |
 |---------------------|-------|----------------------------------------------------|

--- a/strongswan/collector.go
+++ b/strongswan/collector.go
@@ -24,6 +24,7 @@ func NewCollector(viciClientFn viciClientFn, certMetricsEnabled bool) *Collector
 	prefix := "strongswan_"
 	cs := []prometheus.Collector{
 		NewSasCollector(prefix, viciClientFn),
+		NewConnsCollector(prefix, viciClientFn),
 	}
 	if certMetricsEnabled {
 		log.Logger.Info("Certificate metrics enabled.")

--- a/strongswan/conns_collector.go
+++ b/strongswan/conns_collector.go
@@ -1,0 +1,112 @@
+package strongswan
+
+import (
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/strongswan/govici/vici"
+	"github.com/torilabs/ipsec-prometheus-exporter/log"
+)
+
+type ConnsCollector struct {
+	viciClientFn viciClientFn
+
+	connCnt             *prometheus.Desc
+	connConfigured      *prometheus.Desc
+	connChildConfigured *prometheus.Desc
+}
+
+func NewConnsCollector(prefix string, viciClientFn viciClientFn) prometheus.Collector {
+	return &ConnsCollector{
+		viciClientFn: viciClientFn,
+
+		connCnt: prometheus.NewDesc(
+			prefix+"conn_count",
+			"Number of configured connections",
+			nil, nil,
+		),
+		connConfigured: prometheus.NewDesc(
+			prefix+"conn_configured",
+			"Configured IKE connection (always 1 if configured)",
+			[]string{"conn_name"}, nil,
+		),
+		connChildConfigured: prometheus.NewDesc(
+			prefix+"conn_child_configured",
+			"Configured child SA (always 1 if configured)",
+			[]string{"conn_name", "child_name", "local_ts", "remote_ts"}, nil,
+		),
+	}
+}
+
+func (c *ConnsCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.connCnt
+	ch <- c.connConfigured
+	ch <- c.connChildConfigured
+}
+
+func (c *ConnsCollector) Collect(ch chan<- prometheus.Metric) {
+	conns, err := c.listConns()
+	if err != nil {
+		ch <- prometheus.MustNewConstMetric(
+			c.connCnt,
+			prometheus.GaugeValue,
+			float64(0),
+		)
+		return
+	}
+	ch <- prometheus.MustNewConstMetric(
+		c.connCnt,
+		prometheus.GaugeValue,
+		float64(len(conns)),
+	)
+
+	for connName, conn := range conns {
+		ch <- prometheus.MustNewConstMetric(
+			c.connConfigured,
+			prometheus.GaugeValue,
+			1,
+			connName,
+		)
+		for childName, child := range conn.Children {
+			localTSs := strings.Join(child.LocalTS, ";")
+			remoteTSs := strings.Join(child.RemoteTS, ";")
+			ch <- prometheus.MustNewConstMetric(
+				c.connChildConfigured,
+				prometheus.GaugeValue,
+				1,
+				connName, childName, localTSs, remoteTSs,
+			)
+		}
+	}
+}
+
+func (c *ConnsCollector) listConns() (map[string]ConnConfig, error) {
+	s, err := c.viciClientFn()
+	if err != nil {
+		return nil, err
+	}
+	defer s.Close()
+
+	msgs, err := s.StreamedCommandRequest("list-conns", "list-conn", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	res := make(map[string]ConnConfig)
+	for _, m := range msgs {
+		if e := m.Err(); e != nil {
+			log.Logger.Warnf("Message error: %v", e)
+			continue
+		}
+		for _, k := range m.Keys() {
+			rawMsg := m.Get(k).(*vici.Message)
+			var conn ConnConfig
+			if e := vici.UnmarshalMessage(rawMsg, &conn); e != nil {
+				log.Logger.Warnf("Message unmarshal error: %v", e)
+				continue
+			}
+			res[k] = conn
+		}
+	}
+	return res, nil
+}

--- a/strongswan/conns_collector_test.go
+++ b/strongswan/conns_collector_test.go
@@ -1,0 +1,188 @@
+package strongswan
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+	"github.com/strongswan/govici/vici"
+)
+
+func TestConnsCollector_Metrics(t *testing.T) {
+	tests := []struct {
+		name              string
+		viciClientErr     error
+		msgsModifierFn    func(msgs *vici.Message)
+		metricName        string
+		wantMetricsHelp   string
+		wantMetricsType   string
+		wantMetricsLabels string
+		wantMetricsValue  int
+		wantMetricsCount  int
+	}{
+		{
+			name:             "connection error",
+			viciClientErr:    errors.New("some error"),
+			metricName:       "swtest_conn_count",
+			wantMetricsHelp:  "Number of configured connections",
+			wantMetricsType:  "gauge",
+			wantMetricsValue: 0,
+			wantMetricsCount: 1,
+		},
+		{
+			name:             "empty result",
+			metricName:       "swtest_conn_count",
+			wantMetricsHelp:  "Number of configured connections",
+			wantMetricsType:  "gauge",
+			wantMetricsValue: 0,
+			wantMetricsCount: 1,
+		},
+		{
+			name: "error vici messages",
+			msgsModifierFn: func(msgs *vici.Message) {
+				msgs.Set("success", "no")
+				msgs.Set("errmsg", "some error")
+			},
+			metricName:       "swtest_conn_count",
+			wantMetricsHelp:  "Number of configured connections",
+			wantMetricsType:  "gauge",
+			wantMetricsValue: 0,
+			wantMetricsCount: 1,
+		},
+		{
+			name: "one connection count",
+			msgsModifierFn: func(msgs *vici.Message) {
+				msgs.Set("conn-1", vici.NewMessage())
+			},
+			metricName:       "swtest_conn_count",
+			wantMetricsHelp:  "Number of configured connections",
+			wantMetricsType:  "gauge",
+			wantMetricsValue: 1,
+			wantMetricsCount: 2,
+		},
+		{
+			name: "two connections count",
+			msgsModifierFn: func(msgs *vici.Message) {
+				msgs.Set("conn-1", vici.NewMessage())
+				msgs.Set("conn-2", vici.NewMessage())
+			},
+			metricName:       "swtest_conn_count",
+			wantMetricsHelp:  "Number of configured connections",
+			wantMetricsType:  "gauge",
+			wantMetricsValue: 2,
+			wantMetricsCount: 3,
+		},
+		{
+			name: "conn configured",
+			msgsModifierFn: func(msgs *vici.Message) {
+				msgs.Set("my-conn", vici.NewMessage())
+			},
+			metricName:        "swtest_conn_configured",
+			wantMetricsHelp:   "Configured IKE connection (always 1 if configured)",
+			wantMetricsType:   "gauge",
+			wantMetricsLabels: `conn_name="my-conn"`,
+			wantMetricsValue:  1,
+			wantMetricsCount:  2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msgs := vici.NewMessage()
+			if tt.msgsModifierFn != nil {
+				tt.msgsModifierFn(msgs)
+			}
+			c := NewConnsCollector("swtest_", func() (ViciClient, error) {
+				return &fakeViciClient{connMsgs: []*vici.Message{msgs}}, tt.viciClientErr
+			})
+
+			cnt := testutil.CollectAndCount(c)
+			require.Equal(t, tt.wantMetricsCount, cnt, "metrics count")
+
+			wantMetricsContent := fmt.Sprintf(`# HELP %s %s
+# TYPE %s %s
+%s{%s} %d
+`, tt.metricName, tt.wantMetricsHelp, tt.metricName, tt.wantMetricsType, tt.metricName, tt.wantMetricsLabels, tt.wantMetricsValue)
+			if err := testutil.CollectAndCompare(c, strings.NewReader(wantMetricsContent), tt.metricName); err != nil {
+				t.Errorf("unexpected collecting result of '%s':\n%s", tt.metricName, err)
+			}
+		})
+	}
+}
+
+func TestConnsCollector_MetricsChild(t *testing.T) {
+	tests := []struct {
+		name              string
+		childModifierFn   func(msg *vici.Message)
+		metricName        string
+		wantMetricsHelp   string
+		wantMetricsType   string
+		wantMetricsLabels string
+		wantMetricsValue  int
+	}{
+		{
+			name: "child configured with traffic selectors",
+			childModifierFn: func(msg *vici.Message) {
+				msg.Set("local-ts", []string{"10.0.0.0/24"})
+				msg.Set("remote-ts", []string{"192.168.1.0/24"})
+			},
+			metricName:        "swtest_conn_child_configured",
+			wantMetricsHelp:   "Configured child SA (always 1 if configured)",
+			wantMetricsType:   "gauge",
+			wantMetricsLabels: `child_name="child-1",conn_name="my-conn",local_ts="10.0.0.0/24",remote_ts="192.168.1.0/24"`,
+			wantMetricsValue:  1,
+		},
+		{
+			name: "child configured with multiple traffic selectors",
+			childModifierFn: func(msg *vici.Message) {
+				msg.Set("local-ts", []string{"10.0.0.0/24", "10.0.1.0/24"})
+				msg.Set("remote-ts", []string{"192.168.1.0/24", "192.168.2.0/24"})
+			},
+			metricName:        "swtest_conn_child_configured",
+			wantMetricsHelp:   "Configured child SA (always 1 if configured)",
+			wantMetricsType:   "gauge",
+			wantMetricsLabels: `child_name="child-1",conn_name="my-conn",local_ts="10.0.0.0/24;10.0.1.0/24",remote_ts="192.168.1.0/24;192.168.2.0/24"`,
+			wantMetricsValue:  1,
+		},
+		{
+			name:              "child configured without traffic selectors",
+			childModifierFn:   func(msg *vici.Message) {},
+			metricName:        "swtest_conn_child_configured",
+			wantMetricsHelp:   "Configured child SA (always 1 if configured)",
+			wantMetricsType:   "gauge",
+			wantMetricsLabels: `child_name="child-1",conn_name="my-conn",local_ts="",remote_ts=""`,
+			wantMetricsValue:  1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			childMsg := vici.NewMessage()
+			if tt.childModifierFn != nil {
+				tt.childModifierFn(childMsg)
+			}
+			childrenMsg := vici.NewMessage()
+			childrenMsg.Set("child-1", childMsg)
+			connMsg := vici.NewMessage()
+			connMsg.Set("children", childrenMsg)
+			msgs := vici.NewMessage()
+			msgs.Set("my-conn", connMsg)
+
+			c := NewConnsCollector("swtest_", func() (ViciClient, error) {
+				return &fakeViciClient{connMsgs: []*vici.Message{msgs}}, nil
+			})
+
+			cnt := testutil.CollectAndCount(c)
+			require.Equal(t, 3, cnt, "metrics count")
+
+			wantMetricsContent := fmt.Sprintf(`# HELP %s %s
+# TYPE %s %s
+%s{%s} %d
+`, tt.metricName, tt.wantMetricsHelp, tt.metricName, tt.wantMetricsType, tt.metricName, tt.wantMetricsLabels, tt.wantMetricsValue)
+			if err := testutil.CollectAndCompare(c, strings.NewReader(wantMetricsContent), tt.metricName); err != nil {
+				t.Errorf("unexpected collecting result of child '%s':\n%s", tt.metricName, err)
+			}
+		})
+	}
+}

--- a/strongswan/sas_collector_test.go
+++ b/strongswan/sas_collector_test.go
@@ -15,6 +15,7 @@ type fakeViciClient struct {
 	err            error
 	saMsgs         []*vici.Message
 	certMsgs       []*vici.Message
+	connMsgs       []*vici.Message
 	closeTriggered int
 }
 
@@ -24,6 +25,9 @@ func (fvc *fakeViciClient) StreamedCommandRequest(cmd string, event string, _ *v
 	}
 	if cmd == "list-certs" && event == "list-cert" {
 		return fvc.certMsgs, fvc.err
+	}
+	if cmd == "list-conns" && event == "list-conn" {
+		return fvc.connMsgs, fvc.err
 	}
 	return nil, errors.New("invalid command")
 }

--- a/strongswan/struct.go
+++ b/strongswan/struct.go
@@ -62,6 +62,18 @@ type ChildIkeSa struct {
 }
 
 /*
+ConnConfig documentation: https://github.com/strongswan/strongswan/blob/master/src/libcharon/plugins/vici/README.md#list-conns
+*/
+type ConnConfig struct {
+	Children map[string]ConnChildConfig `vici:"children"`
+}
+
+type ConnChildConfig struct {
+	LocalTS  []string `vici:"local-ts"`
+	RemoteTS []string `vici:"remote-ts"`
+}
+
+/*
 Cert documentation: https://github.com/strongswan/strongswan/blob/master/src/libcharon/plugins/vici/README.md#list-cert
 */
 type Cert struct {


### PR DESCRIPTION
  ## Summary
  - Add `ConnsCollector` that exposes configured strongSwan connections via `list-conns` vici command
  - New metrics: `strongswan_conn_count`, `strongswan_conn_configured`, `strongswan_conn_child_configured`                                                    - Enables detection of down tunnels by comparing configured vs active SAs:
    ```promql
    strongswan_conn_child_configured unless on (child_name) strongswan_sa_status

  Changes

  - strongswan/conns_collector.go — new collector using vici.UnmarshalMessage for parsing
  - strongswan/struct.go — ConnConfig and ConnChildConfig structs with vici tags
  - strongswan/collector.go — register ConnsCollector
  - strongswan/conns_collector_test.go — tests for connections and children metrics, error handling
  - strongswan/sas_collector_test.go — extend fakeViciClient with list-conns support
  - README.md — document new metrics and PromQL example

  Test plan

  - Unit tests for connection error (emits conn_count=0)
  - Unit tests for empty result, vici message errors
  - Unit tests for single/multiple connections count
  - Unit tests for child SAs with single/multiple/no traffic selectors
  - All existing tests pass