### PR TITLE
Export configured CHILD_SA inventory and up/down state from list-conns

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ Options and default values:
 | strongswan_*_status | 2     | The tunnel or connection is down.                  |
 | strongswan_*_status | 3     | The tunnel or connection status is not recognized. |
 
+`strongswan_sa_*` metrics are emitted only for active CHILD_SAs returned by `list-sas`.
+
+Additional CHILD_SA inventory metrics are exposed from `list-conns`:
+
+| Metric                      | Value | Description                                                        |
+|----------------------------|-------|--------------------------------------------------------------------|
+| strongswan_child_configured | 1     | The CHILD_SA is currently loaded in strongSwan configuration.      |
+| strongswan_child_up         | 0     | The configured CHILD_SA currently has no active SA.                |
+| strongswan_child_up         | 1     | The configured CHILD_SA currently has an active SA.                |
+
 ## Build & Run
 To build the binary run:
 ```bash

--- a/strongswan/sas_collector.go
+++ b/strongswan/sas_collector.go
@@ -48,6 +48,9 @@ type SasCollector struct {
 	saEstablishSecs *prometheus.Desc
 	saRekeySecs     *prometheus.Desc
 	saLifetimeSecs  *prometheus.Desc
+
+	childConfigured *prometheus.Desc
+	childUp         *prometheus.Desc
 }
 
 func NewSasCollector(prefix string, viciClientFn viciClientFn) prometheus.Collector {
@@ -190,6 +193,16 @@ func NewSasCollector(prefix string, viciClientFn viciClientFn) prometheus.Collec
 			"Seconds until the lifetime expires",
 			[]string{"ike_name", "ike_id", "child_name", "child_id"}, nil,
 		),
+		childConfigured: prometheus.NewDesc(
+			prefix+"child_configured",
+			"Configured CHILD_SA definitions currently loaded in strongSwan",
+			[]string{"ike_name", "child_name", "local_ts", "remote_ts"}, nil,
+		),
+		childUp: prometheus.NewDesc(
+			prefix+"child_up",
+			"Flag if a configured CHILD_SA currently has an active SA",
+			[]string{"ike_name", "child_name", "local_ts", "remote_ts"}, nil,
+		),
 	}
 }
 
@@ -222,6 +235,8 @@ func (c *SasCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.saEstablishSecs
 	ch <- c.saRekeySecs
 	ch <- c.saLifetimeSecs
+	ch <- c.childConfigured
+	ch <- c.childUp
 }
 
 func (c *SasCollector) Collect(ch chan<- prometheus.Metric) {
@@ -245,6 +260,13 @@ func (c *SasCollector) Collect(ch chan<- prometheus.Metric) {
 			c.collectIkeChildMetrics(ikeSa.Name, ikeSa.UniqueID, child, ch)
 		}
 	}
+
+	conns, err := c.listConns()
+	if err != nil {
+		log.Logger.Warnf("list-conns failed: %v", err)
+		return
+	}
+	c.collectConfiguredChildMetrics(conns, sas, ch)
 }
 
 func (c *SasCollector) collectIkeMetrics(ikeSa IkeSa, ch chan<- prometheus.Metric) {
@@ -413,6 +435,39 @@ func (c *SasCollector) collectIkeChildMetrics(name string, uniqueID string, chil
 	)
 }
 
+func (c *SasCollector) collectConfiguredChildMetrics(conns []Conn, sas []IkeSa, ch chan<- prometheus.Metric) {
+	activeChildren := make(map[string]struct{})
+	for _, ikeSa := range sas {
+		for _, child := range ikeSa.Children {
+			activeChildren[childConfigKey(ikeSa.Name, child.Name)] = struct{}{}
+		}
+	}
+
+	for _, conn := range conns {
+		for _, child := range conn.Children {
+			localTSs := strings.Join(child.LocalTS, ";")
+			remoteTSs := strings.Join(child.RemoteTS, ";")
+			ch <- prometheus.MustNewConstMetric(
+				c.childConfigured,
+				prometheus.GaugeValue,
+				float64(1),
+				conn.Name, child.Name, localTSs, remoteTSs,
+			)
+
+			up := 0.0
+			if _, ok := activeChildren[childConfigKey(conn.Name, child.Name)]; ok {
+				up = 1
+			}
+			ch <- prometheus.MustNewConstMetric(
+				c.childUp,
+				prometheus.GaugeValue,
+				up,
+				conn.Name, child.Name, localTSs, remoteTSs,
+			)
+		}
+	}
+}
+
 func (c *SasCollector) listSas() ([]IkeSa, error) {
 	s, err := c.viciClientFn()
 	if err != nil {
@@ -443,6 +498,46 @@ func (c *SasCollector) listSas() ([]IkeSa, error) {
 		}
 	}
 	return res, nil
+}
+
+func (c *SasCollector) listConns() ([]Conn, error) {
+	s, err := c.viciClientFn()
+	if err != nil {
+		return nil, err
+	}
+	defer s.Close()
+
+	msgs, err := s.StreamedCommandRequest("list-conns", "list-conn", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	res := make([]Conn, 0, len(msgs))
+	for _, m := range msgs {
+		if e := m.Err(); e != nil {
+			log.Logger.Warnf("Message error: %v", e)
+			continue
+		}
+		for _, k := range m.Keys() {
+			rawMsg := m.Get(k).(*vici.Message)
+			var conn Conn
+			if e := vici.UnmarshalMessage(rawMsg, &conn); e != nil {
+				log.Logger.Warnf("Message unmarshal error: %v", e)
+				continue
+			}
+			conn.Name = k
+			for childName, child := range conn.Children {
+				child.Name = childName
+				conn.Children[childName] = child
+			}
+			res = append(res, conn)
+		}
+	}
+	return res, nil
+}
+
+func childConfigKey(ikeName string, childName string) string {
+	return ikeName + "\x00" + childName
 }
 
 func viciBoolToInt(v string) int {

--- a/strongswan/sas_collector_test.go
+++ b/strongswan/sas_collector_test.go
@@ -14,6 +14,7 @@ import (
 type fakeViciClient struct {
 	err            error
 	saMsgs         []*vici.Message
+	connMsgs       []*vici.Message
 	certMsgs       []*vici.Message
 	closeTriggered int
 }
@@ -21,6 +22,9 @@ type fakeViciClient struct {
 func (fvc *fakeViciClient) StreamedCommandRequest(cmd string, event string, _ *vici.Message) ([]*vici.Message, error) {
 	if cmd == "list-sas" && event == "list-sa" {
 		return fvc.saMsgs, fvc.err
+	}
+	if cmd == "list-conns" && event == "list-conn" {
+		return fvc.connMsgs, fvc.err
 	}
 	if cmd == "list-certs" && event == "list-cert" {
 		return fvc.certMsgs, fvc.err
@@ -530,4 +534,98 @@ func TestSasCollector_MetricsChild(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSasCollector_ConfiguredChildren(t *testing.T) {
+	tests := []struct {
+		name              string
+		saMsgs            []*vici.Message
+		metricName        string
+		wantMetricsHelp   string
+		wantMetricsType   string
+		wantMetricsLabels string
+		wantMetricsValue  int
+		wantMetricsCount  int
+	}{
+		{
+			name:              "configured child",
+			metricName:        "swtest_child_configured",
+			wantMetricsHelp:   "Configured CHILD_SA definitions currently loaded in strongSwan",
+			wantMetricsType:   "gauge",
+			wantMetricsLabels: `child_name="child-1",ike_name="ike-name",local_ts="local-ts-1;local-ts-2",remote_ts="remote-ts-1;remote-ts-2"`,
+			wantMetricsValue:  1,
+			wantMetricsCount:  3,
+		},
+		{
+			name:              "child up",
+			saMsgs:            []*vici.Message{configuredChildSaMessage()},
+			metricName:        "swtest_child_up",
+			wantMetricsHelp:   "Flag if a configured CHILD_SA currently has an active SA",
+			wantMetricsType:   "gauge",
+			wantMetricsLabels: `child_name="child-1",ike_name="ike-name",local_ts="local-ts-1;local-ts-2",remote_ts="remote-ts-1;remote-ts-2"`,
+			wantMetricsValue:  1,
+			wantMetricsCount:  29,
+		},
+		{
+			name:              "child down",
+			metricName:        "swtest_child_up",
+			wantMetricsHelp:   "Flag if a configured CHILD_SA currently has an active SA",
+			wantMetricsType:   "gauge",
+			wantMetricsLabels: `child_name="child-1",ike_name="ike-name",local_ts="local-ts-1;local-ts-2",remote_ts="remote-ts-1;remote-ts-2"`,
+			wantMetricsValue:  0,
+			wantMetricsCount:  3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewSasCollector("swtest_", func() (ViciClient, error) {
+				return &fakeViciClient{
+					saMsgs:   tt.saMsgs,
+					connMsgs: []*vici.Message{configuredChildConnMessage()},
+				}, nil
+			})
+
+			cnt := testutil.CollectAndCount(c)
+			require.Equal(t, tt.wantMetricsCount, cnt, "metrics count")
+
+			wantMetricsContent := fmt.Sprintf(`# HELP %s %s
+# TYPE %s %s
+%s{%s} %d
+`, tt.metricName, tt.wantMetricsHelp, tt.metricName, tt.wantMetricsType, tt.metricName, tt.wantMetricsLabels, tt.wantMetricsValue)
+			if err := testutil.CollectAndCompare(c, strings.NewReader(wantMetricsContent), tt.metricName); err != nil {
+				t.Errorf("unexpected collecting result of configured child '%s':\n%s", tt.metricName, err)
+			}
+		})
+	}
+}
+
+func configuredChildConnMessage() *vici.Message {
+	childMsg := vici.NewMessage()
+	childMsg.Set("local-ts", []string{"local-ts-1", "local-ts-2"})
+	childMsg.Set("remote-ts", []string{"remote-ts-1", "remote-ts-2"})
+
+	children := vici.NewMessage()
+	children.Set("child-1", childMsg)
+
+	ikeMsg := vici.NewMessage()
+	ikeMsg.Set("children", children)
+
+	msgs := vici.NewMessage()
+	msgs.Set("ike-name", ikeMsg)
+	return msgs
+}
+
+func configuredChildSaMessage() *vici.Message {
+	saMsg := vici.NewMessage()
+	saMsg.Set("name", "child-1")
+	saMsg.Set("uniqueid", "sa-unique-id")
+
+	ikeMsg := vici.NewMessage()
+	ikeMsg.Set("child-sas", map[string]any{"child-sa-name": saMsg})
+	ikeMsg.Set("uniqueid", "some-unique-id")
+
+	msgs := vici.NewMessage()
+	msgs.Set("ike-name", ikeMsg)
+	return msgs
 }

--- a/strongswan/struct.go
+++ b/strongswan/struct.go
@@ -62,6 +62,20 @@ type ChildIkeSa struct {
 }
 
 /*
+Conn documentation: https://github.com/strongswan/strongswan/blob/master/src/libcharon/plugins/vici/README.md#list-conn
+*/
+type Conn struct {
+	Name     string
+	Children map[string]ChildConn `vici:"children"`
+}
+
+type ChildConn struct {
+	Name     string
+	LocalTS  []string `vici:"local-ts"`
+	RemoteTS []string `vici:"remote-ts"`
+}
+
+/*
 Cert documentation: https://github.com/strongswan/strongswan/blob/master/src/libcharon/plugins/vici/README.md#list-cert
 */
 type Cert struct {


### PR DESCRIPTION
## Description

This change adds config-level CHILD_SA metrics on top of the existing runtime SA metrics.

Until now, the exporter only used VICI `list-sas`, which means it only exposed currently active CHILD_SAs. Any configured Phase 2 that was down simply disappeared from the scrape. In practice that made it impossible to distinguish between "not configured", "not loaded", and "configured but currently down".

This patch keeps the existing `strongswan_sa_*` metrics unchanged and adds a second pass via VICI `list-conns` to expose the loaded CHILD_SA inventory.

### New metrics

- `strongswan_child_configured`
- `strongswan_child_up`

### Behavior

- `strongswan_child_configured=1` for every CHILD_SA loaded in strongSwan config
- `strongswan_child_up=1` when that CHILD_SA currently has an active SA
- `strongswan_child_up=0` when it is configured but currently down

This avoids overloading `strongswan_sa_status`, which still reflects active SAs returned by `list-sas` and still carries runtime-only labels such as `child_id` and active traffic selectors.

### Example use case

For a peer with 35 configured Phase 2 tunnels and 29 active ones, the exporter now exposes:

- 35 `strongswan_child_configured` series, all with value `1`
- 35 `strongswan_child_up` series, with 29 at `1` and 6 at `0`
- `strongswan_sa_*` metrics only for the 29 active CHILD_SAs

This makes configured-but-down Phase 2 tunnels visible in Prometheus instead of having them disappear from the scrape.

